### PR TITLE
Update XTcpClient.java

### DIFF
--- a/lib/src/main/java/com/blanke/xsocket/tcp/client/XTcpClient.java
+++ b/lib/src/main/java/com/blanke/xsocket/tcp/client/XTcpClient.java
@@ -70,7 +70,7 @@ public class XTcpClient extends BaseXSocket {
     }
 
     public static XTcpClient getTcpClient(Socket socket, TargetInfo targetInfo, TcpConnConfig connConfig) {
-        if (!socket.isConnected()) {
+        if (!socket.isClosed()) {
             ExceptionUtils.throwException("socket is closeed");
         }
         XTcpClient xTcpClient = new XTcpClient();


### PR DESCRIPTION
7.0Socket源码修改了close方法（源码注释：Once a socket has been closed, it is not available for further networking use (i.e. can't be reconnected or rebound). A new socket needs to be  created.）  所以框架原有断开重连的方法就不能生效  需要重新new Socket   但是原有方法这里传入新的socket会抛出异常    所以这里改成isClosed来判断